### PR TITLE
Update to 1.3.3

### DIFF
--- a/WavFileHandler/App.config
+++ b/WavFileHandler/App.config
@@ -1,6 +1,21 @@
 ﻿<?xml version="1.0" encoding="utf-8" ?>
 <configuration>
+    <configSections>
+        <sectionGroup name="userSettings" type="System.Configuration.UserSettingsGroup, System, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089" >
+            <section name="WavFileHandler.Properties.Settings" type="System.Configuration.ClientSettingsSection, System, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089" allowExeDefinition="MachineToLocalUser" requirePermission="false" />
+        </sectionGroup>
+    </configSections>
     <startup> 
         <supportedRuntime version="v4.0" sku=".NETFramework,Version=v4.7.2" />
     </startup>
+    <userSettings>
+        <WavFileHandler.Properties.Settings>
+            <setting name="SourcePath" serializeAs="String">
+                <value />
+            </setting>
+            <setting name="DestinationPath" serializeAs="String">
+                <value />
+            </setting>
+        </WavFileHandler.Properties.Settings>
+    </userSettings>
 </configuration>

--- a/WavFileHandler/MainForm.cs
+++ b/WavFileHandler/MainForm.cs
@@ -5,6 +5,7 @@ using System.Text;
 using System.Threading.Tasks;
 using System.Windows.Forms;
 using WavFileHandler; // Add this to reference WavFileUtils
+using WavFileHandler.Properties;
 using System.Collections.Concurrent; // Add this to use ConcurrentDictionary
 using System.Windows.Forms.VisualStyles;
 
@@ -18,6 +19,7 @@ namespace WavFileHandlerGUI
         private int _watcherFileCounter = 0; //Watcher File Counter
         private int _processMP3FileCounter = 0;  //Count MP3s Processed
         private static string _logFilePath = "log.txt";
+
 
         public static string LogFilePath
         {
@@ -35,8 +37,9 @@ namespace WavFileHandlerGUI
         public MainForm()
         {
             InitializeComponent();
+            this.Load += MainForm_Load;
+            this.FormClosing += MainForm_FormClosing;
             SetStatusLabelText("Not Started");
-
             _processedFiles = new ConcurrentDictionary<string, DateTime>(); // Initialize the dictionary
         }
 
@@ -280,7 +283,11 @@ namespace WavFileHandlerGUI
             try
             {
                 CartChunk cartChunk = WavFileUtils.ReadCartChunkData(stream);
-                if (cartChunk != null)
+                if (cartChunk == null)
+                {
+                    LogMessage($"File does not contain CART chunk data.");
+                    return;
+                }
                 {
                     // Get the next Sunday date
                     DateTime nextSunday = GetNextSunday(cartChunk.StartDate);
@@ -371,5 +378,18 @@ namespace WavFileHandlerGUI
                 SetStatusLabelText($"Error Updating Log Display: {ex.Message}");
             }
         }
+        private void MainForm_Load(object sender, EventArgs e)
+        {
+            txtSource.Text = Settings.Default.SourcePath;
+            txtDestination.Text = Settings.Default.DestinationPath;
+        }
+
+        private void MainForm_FormClosing(object sender, FormClosingEventArgs e)
+        {
+            Settings.Default.SourcePath = txtSource.Text;
+            Settings.Default.DestinationPath = txtDestination.Text;
+            Settings.Default.Save();
+        }
+
     }
 }

--- a/WavFileHandler/Properties/AssemblyInfo.cs
+++ b/WavFileHandler/Properties/AssemblyInfo.cs
@@ -32,5 +32,5 @@ using System.Runtime.InteropServices;
 // You can specify all the values or you can default the Build and Revision Numbers
 // by using the '*' as shown below:
 // [assembly: AssemblyVersion("1.0.*")]
-[assembly: AssemblyVersion("1.3.2.0")]
+[assembly: AssemblyVersion("1.3.3.0")]
 [assembly: AssemblyFileVersion("1.0.0.0")]

--- a/WavFileHandler/Properties/Settings.Designer.cs
+++ b/WavFileHandler/Properties/Settings.Designer.cs
@@ -8,22 +8,42 @@
 // </auto-generated>
 //------------------------------------------------------------------------------
 
-namespace WavFileHandler.Properties
-{
-
-
+namespace WavFileHandler.Properties {
+    
+    
     [global::System.Runtime.CompilerServices.CompilerGeneratedAttribute()]
-    [global::System.CodeDom.Compiler.GeneratedCodeAttribute("Microsoft.VisualStudio.Editors.SettingsDesigner.SettingsSingleFileGenerator", "11.0.0.0")]
-    internal sealed partial class Settings : global::System.Configuration.ApplicationSettingsBase
-    {
-
+    [global::System.CodeDom.Compiler.GeneratedCodeAttribute("Microsoft.VisualStudio.Editors.SettingsDesigner.SettingsSingleFileGenerator", "17.5.0.0")]
+    internal sealed partial class Settings : global::System.Configuration.ApplicationSettingsBase {
+        
         private static Settings defaultInstance = ((Settings)(global::System.Configuration.ApplicationSettingsBase.Synchronized(new Settings())));
-
-        public static Settings Default
-        {
-            get
-            {
+        
+        public static Settings Default {
+            get {
                 return defaultInstance;
+            }
+        }
+        
+        [global::System.Configuration.UserScopedSettingAttribute()]
+        [global::System.Diagnostics.DebuggerNonUserCodeAttribute()]
+        [global::System.Configuration.DefaultSettingValueAttribute("")]
+        public string SourcePath {
+            get {
+                return ((string)(this["SourcePath"]));
+            }
+            set {
+                this["SourcePath"] = value;
+            }
+        }
+        
+        [global::System.Configuration.UserScopedSettingAttribute()]
+        [global::System.Diagnostics.DebuggerNonUserCodeAttribute()]
+        [global::System.Configuration.DefaultSettingValueAttribute("")]
+        public string DestinationPath {
+            get {
+                return ((string)(this["DestinationPath"]));
+            }
+            set {
+                this["DestinationPath"] = value;
             }
         }
     }

--- a/WavFileHandler/Properties/Settings.settings
+++ b/WavFileHandler/Properties/Settings.settings
@@ -1,7 +1,12 @@
 ﻿<?xml version='1.0' encoding='utf-8'?>
-<SettingsFile xmlns="http://schemas.microsoft.com/VisualStudio/2004/01/settings" CurrentProfile="(Default)">
-  <Profiles>
-    <Profile Name="(Default)" />
-  </Profiles>
-  <Settings />
+<SettingsFile xmlns="http://schemas.microsoft.com/VisualStudio/2004/01/settings" CurrentProfile="(Default)" GeneratedClassNamespace="WavFileHandler.Properties" GeneratedClassName="Settings">
+  <Profiles />
+  <Settings>
+    <Setting Name="SourcePath" Type="System.String" Scope="User">
+      <Value Profile="(Default)" />
+    </Setting>
+    <Setting Name="DestinationPath" Type="System.String" Scope="User">
+      <Value Profile="(Default)" />
+    </Setting>
+  </Settings>
 </SettingsFile>

--- a/WavFileHandler/Settings.cs
+++ b/WavFileHandler/Settings.cs
@@ -1,0 +1,28 @@
+﻿namespace WavFileHandler.Properties {
+    
+    
+    // This class allows you to handle specific events on the settings class:
+    //  The SettingChanging event is raised before a setting's value is changed.
+    //  The PropertyChanged event is raised after a setting's value is changed.
+    //  The SettingsLoaded event is raised after the setting values are loaded.
+    //  The SettingsSaving event is raised before the setting values are saved.
+    internal sealed partial class Settings {
+        
+        public Settings() {
+            // // To add event handlers for saving and changing settings, uncomment the lines below:
+            //
+            // this.SettingChanging += this.SettingChangingEventHandler;
+            //
+            // this.SettingsSaving += this.SettingsSavingEventHandler;
+            //
+        }
+        
+        private void SettingChangingEventHandler(object sender, System.Configuration.SettingChangingEventArgs e) {
+            // Add code to handle the SettingChangingEvent event here.
+        }
+        
+        private void SettingsSavingEventHandler(object sender, System.ComponentModel.CancelEventArgs e) {
+            // Add code to handle the SettingsSaving event here.
+        }
+    }
+}

--- a/WavFileHandler/WavFileHandler.csproj
+++ b/WavFileHandler/WavFileHandler.csproj
@@ -62,6 +62,7 @@
   </ItemGroup>
   <ItemGroup>
     <Compile Include="CartChunk.cs" />
+    <Compile Include="Settings.cs" />
     <Compile Include="WavFileInfoForm.cs">
       <SubType>Form</SubType>
     </Compile>


### PR DESCRIPTION
 With better handling of WAV files that do have CART chunk data.

Added "tryReadBytes" method to the WavFileUtils that checks to see if there are enough bytes left in the file to read the field. If this fails cartChunk returns null.

Updated UpdateCartChunkEndDate method to check if cartChunk is null and, if so, log a message that there was no cart chunk data in the wav file.

Added Settings.cs to save sourcePath and destinationPath across runs for ease of use.